### PR TITLE
remove docker-compose down command from system-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@q6-enterprises-inc/fluture-file-send",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Future returning, easy way of sending files.",
   "main": "index.js",
   "scripts": {
     "test": "NODE_ENV='development' mocha --recursive tests/integration tests/unit",
-    "system-test": "docker-compose up --build --abort-on-container-exit --exit-code-from test-server; docker-compose down -v",
+    "system-test": "docker-compose up --build --abort-on-container-exit --exit-code-from test-server",
     "system-test-suite": "NODE_ENV='development' mocha --recursive tests/system",
     "lint": "eslint ./"
   },


### PR DESCRIPTION
down command interferes with error reporting in ci/cd pipelines as it
will return success when the down command succeeds even if the tests
return a non zero exit code